### PR TITLE
Update vignette.gdshader

### DIFF
--- a/resource/vignette.gdshader
+++ b/resource/vignette.gdshader
@@ -1,23 +1,35 @@
 shader_type canvas_item;
 
-uniform vec2 viewport_size; // Size of the viewport
+// Size of the viewport (should be passed in from script)
+uniform vec2 viewport_size;
+
+// Vignette parameters (expressed as factors relative to the maximum distance from the center)
+uniform float inner_radius_factor : hint_range(0.0, 1.0) = 0.7;
+uniform float outer_radius_factor : hint_range(0.0, 1.0) = 1.0;
+uniform float vignette_strength : hint_range(0.0, 1.0) = 0.8;
+
+// Tint color for the vignette (default is black)
+uniform vec3 vignette_color : hint_color = vec3(0.0);
 
 void fragment() {
-    // Calculate the center of the viewport
-    vec2 center = viewport_size / 2.0;
+    // Calculate the center of the viewport.
+    vec2 center = viewport_size * 0.5;
     
-    // Convert fragment coordinates to viewport coordinates
-    vec2 frag_coord = FRAGCOORD.xy;
+    // Compute the maximum distance from the center to any corner.
+    float max_dist = length(viewport_size) * 0.5;
     
-    // Calculate the distance from the fragment to the center of the viewport
-    float dist = distance(frag_coord, center);
+    // Determine inner and outer radii for the vignette effect.
+    float inner_radius = max_dist * inner_radius_factor;
+    float outer_radius = max_dist * outer_radius_factor;
     
-    // Calculate the radius of the vignette effect
-    float radius = length(viewport_size) / 2.0;
+    // Calculate the distance from the current fragment to the center.
+    float dist = distance(FRAGCOORD.xy, center);
     
-    // Calculate the vignette intensity
-    float vignette = smoothstep(radius, radius * 0.7, dist);
+    // Smoothly interpolate between the inner and outer radii.
+    float t = smoothstep(inner_radius, outer_radius, dist);
     
-    // Apply the vignette effect
-    COLOR.rgb *= vignette;
+    // Blend the original color with the vignette color.
+    // At the center (t=0) the original color remains unchanged;
+    // at the edges (t=1), the color is tinted by 'vignette_color' based on 'vignette_strength'.
+    COLOR.rgb = mix(COLOR.rgb, vignette_color, t * vignette_strength);
 }


### PR DESCRIPTION
Center & Maximum Distance: The shader computes the center of the viewport and uses half the length of the viewport (diagonally) as the maximum distance. Dynamic Radii: Using inner_radius_factor and outer_radius_factor, the shader calculates the inner and outer boundaries of the vignette effect. Smooth Transition: The smoothstep function creates a gradual transition between the two radii. Color Blending: Finally, the shader uses mix to blend the fragment’s original color with the specified vignette color, scaled by the computed transition factor and overall strength. This enhanced version provides you with more control over the vignette appearance and can be easily adjusted to suit different aesthetic needs.