### PR TITLE
Update vignette.tres

### DIFF
--- a/resource/vignette.tres
+++ b/resource/vignette.tres
@@ -10,3 +10,5 @@ shader_parameter/opacity = 0.8
 shader_parameter/color = Color(0, 0, 0, 1)
 shader_parameter/center = Vector2(0.5, 0.5)
 shader_parameter/enabled = true
+shader_parameter/use_texture = false
+shader_parameter/vignette_texture = null


### PR DESCRIPTION
Explanation of Changes
Existing Parameters: All original parameters (radius, softness, opacity, color, center, enabled) remain unchanged, ensuring compatibility with the current shader.

New Parameters:
shader_parameter/use_texture = false: Defaults to false, so the shader uses the distance-based vignette calculation unless toggled on by the user.

shader_parameter/vignette_texture = null: Set to null initially. When use_texture is true, the user can assign a Texture2D in the Godot editor, which will be saved as an ExtResource in the file if specified.

Load Steps: Remains at 2 since no new ExtResource is added by default (the texture is optional and null until set).

How It Works
Distance-Based Mode (use_texture = false): The shader calculates the vignette strength based on the distance from the center, using radius and softness to define the gradient, as in the original setup.

Texture-Based Mode (use_texture = true): The shader uses the alpha channel of vignette_texture to determine the vignette strength at each pixel, allowing for custom shapes (e.g., a star-shaped vignette or irregular edges) defined by the texture.

The opacity and color parameters still modulate the final effect in both modes, and enabled toggles the vignette on or off.