### PR TITLE
Update standard_richtext.tscn

### DIFF
--- a/object/rich_text_label.gd
+++ b/object/rich_text_label.gd
@@ -1,0 +1,25 @@
+extends RichTextLabel
+
+@onready var timer = $TypingTimer
+@onready var audio = $AudioStreamPlayer
+var full_text = "[center][b]Welcome to Chaos[/b]\nUnleash the Glow[/center]"
+
+func _ready():
+    text = full_text
+    visible_characters = 0
+    timer.connect("timeout", _on_timer_timeout)
+    timer.start()
+
+func _on_timer_timeout():
+    if visible_characters < full_text.length():
+        visible_characters += 1
+        audio.pitch_scale = randf_range(0.9, 1.1)  # Slight pitch variation
+        audio.play()
+    else:
+        timer.stop()
+
+func _process(delta):
+    # Optional: Pulse glow effect
+    var glow = theme_override_colors/font_outline_color
+    glow.a = 0.8 + sin(Time.get_ticks_msec() * 0.001) * 0.2
+    add_theme_color_override("font_outline_color", glow)

--- a/object/standard_richtext.tscn
+++ b/object/standard_richtext.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://dtlxh87hqokhp"]
+[gd_scene load_steps=6 format=3 uid="uid://dtlxh87hqokhp"]
 
 [ext_resource type="FontFile" uid="uid://b385mxjpb2l0b" path="res://font/xolonium/Xolonium-Regular.ttf" id="1_glv3e"]
 [ext_resource type="FontFile" uid="uid://csv62pf5suogx" path="res://font/xolonium/Xolonium-Bold.ttf" id="1_xjap1"]
@@ -19,15 +19,37 @@ theme_override_font_sizes/normal_font_size = 20
 theme_override_font_sizes/bold_font_size = 20
 theme_override_colors/default_color = Color(1, 1, 1, 1)  # White for clarity
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.5)  # Subtle shadow
+theme_override_colors/font_outline_color = Color(1, 0.8, 0, 0.8)  # Glow effect (yellowish)
+theme_override_constants/outline_size = 2  # Thin outline for glow
 theme_override_constants/shadow_offset_x = 2
 theme_override_constants/shadow_offset_y = 2
 bbcode_enabled = true
 fit_content = true
-scroll_active = false  # Disable scrolling by default
+scroll_active = false
 text = "[center][b]Welcome to Chaos[/b]\nUnleash the Glow[/center]"
 script = ExtResource("2_kp8m3")
+visible_characters = 0  # Start hidden for typing effect
+
+[node name="TypingTimer" type="Timer" parent="."]
+wait_time = 0.05  # Speed of typing effect
+one_shot = false
+autostart = false
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("3_audio")
-volume_db = -10.0  # Lowered volume for subtlety
+volume_db = -10.0  # Subtle volume
+pitch_scale = 1.0  # Base pitch, vary in script
 autoplay = false
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+autoplay = "fade_in"
+
+[animation "fade_in" length=1.0]
+track_0/path = NodePath(".:modulate")
+track_0/interp = 1
+track_0/loop_wrap = true
+track_0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}


### PR DESCRIPTION
1. Add a Typing Effect for Text Display A subtle typing animation can make the text feel more dynamic. We can use a Timer node to trigger the text reveal in the attached script (rich_text_label.gd). Let’s add the Timer as a child node. Change:
Add a Timer node under RichTextLabel.

Configure it with a reasonable wait time (e.g., 0.05 seconds) for character-by-character display.

2. Enhance Visual Feedback with a Glow Effect Since the text mentions "Unleash the Glow," let’s add a mild glow via a theme_override_colors/font_outline_color and modulate it in the script for a pulsing effect. This keeps it visually engaging without overcomplicating the scene. Change:
Add outline properties to the RichTextLabel for a glow-like outline.

Suggest script logic (though we won’t implement it fully here).

3. Improve Audio Integration The AudioStreamPlayer is set to autoplay = false, which is fine, but we could tie it to the typing effect for a "text tick" sound per character. Let’s also add a slight pitch variation for a more natural feel. Change:
Add a pitch_scale property with a mild random range (e.g., 0.9 to 1.1) in the script.

Keep volume subtle but adjustable.

4. Add Animation for Entrance A gentle fade-in or scale-up animation would make the text’s appearance smoother. We’ll use an AnimationPlayer node to handle this. Change:
Add an AnimationPlayer node with a simple fade-in animation.

Set it to autoplay on scene load.